### PR TITLE
fix(): rewind button glitch

### DIFF
--- a/VideoPlayer.js
+++ b/VideoPlayer.js
@@ -1062,8 +1062,15 @@ export default class VideoPlayer extends Component {
           <SafeAreaView
             style={[styles.controls.row, styles.controls.bottomControlGroup]}>
             {playPauseControl}
-            {this.renderBackRewind()}
-            {this.renderFastForward()}
+            <View
+              style={{
+                display: 'flex',
+                flexDirection: 'row',
+                justifyContent: 'space-between',
+              }}>
+              {this.renderBackRewind()}
+              {this.renderFastForward()}
+            </View>
             {this.renderTitle()}
             {timerControl}
           </SafeAreaView>
@@ -1120,7 +1127,7 @@ export default class VideoPlayer extends Component {
     return this.renderControl(
       <Image
         source={require('./assets/img/fastForward.png')}
-        style={{width: 15, height: 15, marginRight: 20}}
+        style={{width: 15, height: 15}}
       />,
       this.methods.fastForward,
     );
@@ -1133,7 +1140,7 @@ export default class VideoPlayer extends Component {
     return this.renderControl(
       <Image
         source={require('./assets/img/backRewind.png')}
-        style={{width: 15, height: 15, marginLeft: 20, marginRight: -70}}
+        style={{width: 15, height: 15}}
       />,
       this.methods.backRewind,
     );


### PR DESCRIPTION
# Summary of the changes

<!-- highlight the main point of the proposed changes -->

1. use view to wrap the rewind button and fast forward button to prevent glitch
2.
3.

## Reference to the cards / issues / tickets

<!-- eg: insert the links or the reference photos / images here -->
<!-- eg: https://github.com/lava-x/react-native-skeleton/pull/30 -->

Some links or reference here

## Screenshots / Videos

<!-- insert app screenshots here -->

Some links or reference here

## Need review from

<!-- insert the person you wish to mention here -->
<!-- eg: @mentionPersonA -->

@mention someone here

---

Put an `x` in all the boxes that apply

## Checklist (Practice)

- [ ] I did linting my code locally prior to push.
- [ ] I followed the standard error message and success message format.
- [ ] I did follow the naming convention in constant/variable name and function name.
- [ ] I confirmed there is no single file exceeded 300 lines of code. (ideally 200 lines or less, average around 100)
- [ ] I checked there is no unhandled nor silent `catch`.
- [ ] I checked there is no `console.log`
- [ ] I have tested the feature I added throughly
- [ ] I have tested my code does not effect any core features (Zoom, Payment, Video playback..etc)
- [ ] I tidy up my code to make sure its readable to others
- [ ] I wrote comments for the `props` I defined
- [ ] My PR requires a specific backend branch

## UI

<!-- remove the one that is not relevant -->

- [ ] I did handle the `loading` state.
- [ ] I did handle the `error` state.
- [ ] I did handle the form `inital value`, `events`, correctly
- [ ] I used default value for `props`, `state`, etc
- [ ] I used `i18n` in all the text string.
- [ ] I followed the UI styling practice for components.
- [ ] I followed the mockup design for what I've worked on.
- [ ] I checked the spacing & alignment between elements on the screen. (left, right, top, bottom)
- [ ] I checked the quick double tap button issue (show loading after first tap, then prevent second tap until a response from server)

## Breaking Changes

<!-- remove the one that is not relevant -->

- [ ] My changes does not break things.
- [ ] My changes causes others code to break.
- [ ] I have well informed others who work on the relevant codes.

## Documentation

<!-- remove the one that is not relevant -->

- [ ] My change does not requires changing documentation.
- [ ] There are changes require in the documentation.
- [ ] I have updated the documentation accordingly.

## Clickup Task

<!-- add related clickup task here -->

- [ ] [#taskname](url)
